### PR TITLE
fixed multiple events uninstallation during compose update action

### DIFF
--- a/src/BitrixEventsPlugin/Event/EventProcessor.php
+++ b/src/BitrixEventsPlugin/Event/EventProcessor.php
@@ -33,6 +33,10 @@ final class EventProcessor implements ProcessEventInterface
      * @var bool
      */
     private $isProcessed = false;
+    /**
+     * @var array
+     */
+    private $packagesWithUninstalledEvents = [];
 
     /**
      * EventProcessor constructor.
@@ -123,7 +127,10 @@ final class EventProcessor implements ProcessEventInterface
              * @todo update with diff
              */
             case EventTypeRegistry::EVENT_TYPE_UPDATE:
-                $this->uninstallEvents($eventModel->getPackage());
+                if(!isset($this->packagesWithUninstalledEvents[$eventModel->getPackage()])){
+                    $this->uninstallEvents($eventModel->getPackage());
+                    $this->packagesWithUninstalledEvents[$eventModel->getPackage()] = true;
+                }
                 $this->installEvent($eventModel);
                 break;
             case EventTypeRegistry::EVENT_TYPE_INSTALL:


### PR DESCRIPTION
Сейчас при update перед установкой каждого события, плагин уничтожает все вообще события нужного пакета, что приводит к тому, что реально устанавливается только последний ивент. Поэтому я добавил массив для сохранения пакетов, чьи события уже были удалены, чтобы избежать многократного удаления